### PR TITLE
make print method return 'PHom' object invisibly + add test

### DIFF
--- a/R/PHom.R
+++ b/R/PHom.R
@@ -255,6 +255,8 @@ print.PHom <- function(x, ...) {
                  "")
   
   cat(paste(ans1, ans2, ans3, sep = "\n\n"))
+  
+  invisible(x)
 }
 
 #' First Part of PHom Object

--- a/tests/testthat/test-print.R
+++ b/tests/testthat/test-print.R
@@ -1,0 +1,17 @@
+context("printing")
+
+# arbitrary 'PHom' object
+x <- cbind(
+  x = runif(n = 24L),
+  y = runif(n = 24L)
+)
+x_vr <- vietoris_rips(x, dimension = 2L)
+
+test_that("`print()` method returns 'PHom' object invisibly", {
+  # detect printed output
+  expect_output(out <- print(x_vr), "PHom object")
+  # confirm common class
+  expect_equal(class(x_vr), class(out))
+  # test equality
+  expect_equal(x_vr, out)
+})


### PR DESCRIPTION
This PR makes a subtle but significant change to `ripserr:::print.PHom()`: After `cat()`ing content to the console, it invisibly returns the original, unchanged object. I recommend the change for two reasons:

1. It is generally expected. (See the documentation for `base::print()`.)
2. It permits a convenient print-and-define ending to a pipeline, e.g. `data %>% vietoris_rips(max_dim = 2L) %>% print() -> data_vr`.