### PR TITLE
ignore 'ignore' folder during R build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,6 +10,7 @@
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+^ignore$
 ^README\.Rmd$
 ^cran-comments\.md$
 ^NEWS\.md$


### PR DESCRIPTION
Since '.gitignore' ignores a folder called 'ignore', '.Rbuildignore' should also ignore this folder, to avoid surprising warnings during build. : )